### PR TITLE
fix: unexpected return result when

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsxpath",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "XPath like notation to query a JSON object",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/ts/path/Postfix.spec.ts
+++ b/ts/path/Postfix.spec.ts
@@ -430,6 +430,112 @@ describe('Class Postfix', () => {
       ];
       expect(postfixInstance.toPostfix(path)).toEqual(expected);
     });
+
+    it('path is /*[name()="a" or name()="b"]', () => {
+      const path = '/*[name()="a" or name()="b"]';
+      expected = [
+        {
+          type: TYPES.rootPath,
+          value: "/*",
+          callerId: 'main'
+        },
+        [
+          {
+            type: TYPES.arguments,
+            value: []
+          },
+          {
+            type: TYPES.function,
+            value: 'name',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.string,
+            value: 'a'
+          },
+          {
+            type: TYPES.operator,
+            value: '=',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.arguments,
+            value: []
+          },
+          {
+            type: TYPES.function,
+            value: 'name',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.string,
+            value: 'b'
+          },
+          {
+            type: TYPES.operator,
+            value: '=',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.operator,
+            value: 'or',
+            callerId: 'main'
+          }
+        ]
+      ];
+      expect(postfixInstance.toPostfix(path)).toEqual(expected);
+    });
+
+    it('path is //*[local-name()="a" and sibling::b="c"]', () => {
+      const path = '//*[local-name()="a" and sibling::b="c"]';
+      expected = [
+        {
+          type: TYPES.rootPath,
+          value: "//*",
+          callerId: 'main'
+        },
+        [
+          {
+            type: TYPES.arguments,
+            value: []
+          },
+          {
+            type: TYPES.function,
+            value: 'local-name',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.string,
+            value: 'a'
+          },
+          {
+            type: TYPES.operator,
+            value: '=',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.path,
+            value: './sibling::b',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.string,
+            value: 'c'
+          },
+          {
+            type: TYPES.operator,
+            value: '=',
+            callerId: 'main'
+          },
+          {
+            type: TYPES.operator,
+            value: 'and',
+            callerId: 'main'
+          }
+        ]
+      ];
+      expect(postfixInstance.toPostfix(path)).toEqual(expected);
+    });
   });
 
   describe('Variables', () => {

--- a/ts/path/Postfix.ts
+++ b/ts/path/Postfix.ts
@@ -309,6 +309,10 @@ export class Postfix {
           }
           this.stacks.operators.push(subPath);
           subPath = '';
+        } else if (this.tests.isStringValue(subPath)) {
+          this.stacks.output.push(this.setType(subPath));
+          subPath = '';
+        
         } else if (subPath.length && (
           !this.tests.isFunctionName(subPath+this.props.trimmedInput[this.props.pathIndex+1]) && 
           !this.tests.isPosition(subPath+this.props.trimmedInput[this.props.pathIndex+1]) &&


### PR DESCRIPTION
- "and" or "or" operator is after a string value in predicate expression